### PR TITLE
iTunes Preview on ConcertInfo page

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -16,3 +16,11 @@ body{
     background-color:lightgrey;
     height: 90px;
 }
+#frame2 {
+    margin-top: 105px;
+    margin-left: -248px;
+}
+#frame3 {
+    margin-top: 210px;
+    margin-left: -248px;
+}

--- a/html/concertPage.html
+++ b/html/concertPage.html
@@ -64,15 +64,17 @@
         </div>
 
         <div id="concertSpotify" class="d-flex flex-column m-3">
-            <div style="height: 150px; width: 200px; border: 1px solid black;" id="artistPicture">
+            <div style="height: 150px; width: 250px; border: 1px solid black;" id="artistPicture">
                 <!-- add artist image here-->
             </div>
             <div id="artistInfo" class="d-flex flex-column align-items-center">
-                <h5 class="mb-1">Post Malone</h5>
-                <p class="mb-1">Texas, USA</p>
+                <h5 id="artistName" class="mb-1">Post Malone</h5>
+                <p id="artistOrigin" class="mb-1">Texas, USA</p>
             </div>
-            <div id="itunesPlaylist" style="height: 300px; width: 200px; border: 1px solid black;" id="artistSpotify" class="d-flex">
-
+            <div id="itunesPlaylist" style="height: 362px; width: 250px; border: 1px solid black;" id="artistSpotify" class="d-flex">
+                <iframe id="frame1" allow="autoplay *; encrypted-media *;" style="width:100%;max-width:250px;overflow:hidden;background:transparent;" src="https://embed.music.apple.com/us/album/bang-on-em/220312813?i=220321847&app=music" height="150" frameborder="0"></iframe>
+                <iframe id="frame2" allow="autoplay *; encrypted-media *;" style="width:100%;max-width:250px;overflow:hidden;background:transparent;" src="https://embed.music.apple.com/us/album/stuck-on-you/220312813?i=220316536&app=music" height="150" frameborder="0"></iframe>
+                <iframe id="frame3" allow="autoplay *; encrypted-media *;" style="width:100%;max-width:250px;overflow:hidden;background:transparent;" src="https://embed.music.apple.com/us/album/return-of-the-mac-aka-new-york-s/220312813?i=220313297&app=music" height="150" frameborder="0"></iframe>
             </div>
         </div>
 
@@ -83,7 +85,7 @@
 
     </footer>
 
-    <script src="../js/index.js"></script>
+    <script src="../js/page2.js"></script>
 
 </body>
 

--- a/js/page2.js
+++ b/js/page2.js
@@ -1,24 +1,25 @@
-//---------- Need : Get artist name from local storage -----------
-var artist = sessionStorage.getItem("artist");
-var artistIMG = sessionStorage.getItem("artistIMG");
-//----------------------------------------------------------------
-console.log(artist);
-console.log(artistIMG);
 
-var queryURL = "https://itunes.apple.com/search?term="+ artist +"&limit=6";
-var queryURL2 = "";
+var artist = "YBN Nahmir";
+var queryURL = "https://itunes.apple.com/search?term=" + artist + "&limit=3";
 
 var artistName = "";
 var artistURL = "";
 var artistID = "";
 var country = "";
 
+var trackURL = "";
+var trackUrlCut = "";
+var playSRC = "";
+
+var frame1;
+var frame2;
+var frame3;
+
 $.ajax({
     url: queryURL,
     dataType: 'JSONP', //This gets a JSON object instead of the default UTF8 result.
     method: "GET"
 }).then(function (response) {
-    console.log(response.results);
     var results = response.results;
 
     artistName = results[0].artistName;// Gets the Artist name for preview
@@ -26,17 +27,25 @@ $.ajax({
     artistID = results[0].artistId;
     country = response.results[0].country;// Gets the Artist Country for preview.
 
-    queryURL2 = "https://itunes.apple.com/lookup?id=" + artistID;//
+    $("#artistName").text(artistName);//Update the Artist name from iTunes
+    $("#artistOrigin").text(country);//Update the Artist
 
-    call2();
+        // Get trackURL for the first embed
+        trackURL = results[0].trackViewUrl;
+        trackUrlCut = trackURL.slice(34, trackURL.length - 5);
+        playSRC = "https://embed.music.apple.com/us/album/" + trackUrlCut + "&app=music"
+        $("#frame1").attr("src", playSRC);
+
+        // Get trackURL for the second embed
+        trackURL = results[1].trackViewUrl;
+        trackUrlCut = trackURL.slice(34, trackURL.length - 5);
+        playSRC = "https://embed.music.apple.com/us/album/" + trackUrlCut + "&app=music"
+        $("#frame2").attr("src", playSRC);
+
+        // Get trackURL for the third embed
+        trackURL = results[2].trackViewUrl;//Get full trackURL
+        trackUrlCut = trackURL.slice(34, trackURL.length - 5);//Cut out useless pieces of trackURL
+        playSRC = "https://embed.music.apple.com/us/album/" + trackUrlCut + "&app=music";//Place the part of trackURL kept into the embed src
+        $("#frame3").attr("src", playSRC);
+
 });
-
-function call2() {
-    $.ajax({
-        url: queryURL2,
-        dataType: "JSONP",
-        method: "GET"
-    }).then(function (response) {
-        console.log(response.results);
-    });
-}


### PR DESCRIPTION
Removal of console logs, also removed the whole second ajax call on page2.js and the session storage that had no use.

****  iTunes is hard coded to the variable "artist" right now ****

Added 2 styles on main.css
Gave some elements IDs
Had to make the song preview section slightly wider to fit
2 lines of code on page2.js to update the artist info above the  song previews